### PR TITLE
Prefer to read configuration from $KDCPROXY_CONFIG

### DIFF
--- a/kdcproxy/config/__init__.py
+++ b/kdcproxy/config/__init__.py
@@ -24,6 +24,7 @@
 import importlib
 import itertools
 import logging
+import os
 import socket
 import sys
 
@@ -50,10 +51,12 @@ class IConfig(IResolver):
 class KDCProxyConfig(IConfig):
     GLOBAL = "global"
 
-    def __init__(self, file="/etc/kdcproxy.conf"):
+    def __init__(self, filename=None):
         self.__cp = configparser.ConfigParser()
+        if not filename and os.environ.has_key("KDCPROXY_CONFIG"):
+            filename = os.environ["KDCPROXY_CONFIG"]
         try:
-            self.__cp.read(file)
+            self.__cp.read(filename or "/etc/kdcproxy.conf")
         except configparser.Error:
             logging.log(logging.ERROR, "Unable to read config file: %s" % file)
 


### PR DESCRIPTION
If $KDCPROXY_CONFIG is defined, try to read it instead of
/etc/kdcproxy.conf.  Otherwise, read /etc/kdcproxy.conf, as
we did before.  Proposed for issue #4.
