### PR TITLE
Handle python3's socket.SOCK_NONBLOCK more cleanly

### DIFF
--- a/kdcproxy/__init__.py
+++ b/kdcproxy/__init__.py
@@ -87,7 +87,7 @@ class Application:
 
             for sock in w:
                 try:
-                    if sock.type & ~socket.SOCK_NONBLOCK == socket.SOCK_DGRAM:
+                    if self.sock_type(sock) == socket.SOCK_DGRAM:
                         # If we proxy over UDP, remove the 4-byte length
                         # prefix since it is TCP only.
                         sock.sendall(pr.request[4:])
@@ -105,7 +105,7 @@ class Application:
 
                     # If we proxy over UDP, we will be missing the 4-byte
                     # length prefix. So add it.
-                    if sock.type & ~socket.SOCK_NONBLOCK == socket.SOCK_DGRAM:
+                    if self.sock_type(sock) == socket.SOCK_DGRAM:
                         reply = struct.pack("!I", len(reply)) + reply
 
                     return reply
@@ -125,6 +125,12 @@ class Application:
             return False
 
         return True
+
+    def sock_type(self, sock):
+        try:
+            return sock.type & ~socket.SOCK_NONBLOCK
+        except AttributeError:
+            return sock.type
 
     def __call__(self, env, start_response):
         try:
@@ -198,7 +204,7 @@ class Application:
 
                     # Resend packets to UDP servers
                     for sock in tuple(rsocks):
-                        if sock.type & ~socket.SOCK_NONBLOCK == socket.SOCK_DGRAM:
+                        if self.sock_type(sock) == socket.SOCK_DGRAM:
                             wsocks.append(sock)
                             rsocks.remove(sock)
 


### PR DESCRIPTION
Use the fact that python2 doesn't mix socket.SOCK_NONBLOCK in with
socket .type attributes to add a helper method that does the right
thing for both, and use it when reading back a socket's type.
