### PR TITLE
Work around read() not finishing under paste

### DIFF
--- a/kdcproxy/__init__.py
+++ b/kdcproxy/__init__.py
@@ -136,7 +136,11 @@ class Application:
 
             # Parse the request
             try:
-                pr = codec.decode(env["wsgi.input"].read())
+                length = int(env["CONTENT_LENGTH"])
+            except AttributeError:
+                length = -1
+            try:
+                pr = codec.decode(env["wsgi.input"].read(length))
             except codec.ParsingError as e:
                 raise HTTPException(400, e.message)
 


### PR DESCRIPTION
When run from mod_wsgi, env["wsgi.input"].read()'s default behavior of
reading until the end of the data is reached pulls in the rest of the
client's request.  Under paste with SSL, it blocks.  So if the client
sent a Content-Length header, stop after reading just that many bytes.
