### PR TITLE
Always instantiate an application

### DIFF
--- a/kdcproxy/__init__.py
+++ b/kdcproxy/__init__.py
@@ -224,5 +224,4 @@ class Application:
             start_response(str(e), e.headers)
             return [e.message]
 
-if __name__ == "__main__":
-    application = Application()
+application = Application()


### PR DESCRIPTION
When run under mod_wsgi, we're invoked as 'kdcproxy', so we don't supply
the application object that it expects.  This patch just removes the conditional
logic and always instantiates one.
