### PR TITLE
Eliminate import error message

### DIFF
--- a/kdcproxy/__init__.py
+++ b/kdcproxy/__init__.py
@@ -27,10 +27,10 @@ import struct
 import sys
 import time
 
-try:  # Python 3.x
+if (sys.version_info.major >= 3): # Python 3.x
     import http.client as httplib
     import urllib.parse as urlparse
-except ImportError:  # Python 2.x
+else:
     import httplib
     import urlparse
 


### PR DESCRIPTION
Avoid logging an error message due to a failing import.  Key the
attempted import off the Python version rather than trying, failing, and
falling back.
