### PR TITLE
Wb retrytimeout

### DIFF
--- a/kdcproxy/__init__.py
+++ b/kdcproxy/__init__.py
@@ -27,10 +27,10 @@ import struct
 import sys
 import time
 
-try:  # Python 3.x
+if (sys.version_info.major >= 3): # Python 3.x
     import http.client as httplib
     import urllib.parse as urlparse
-except ImportError:  # Python 2.x
+else:
     import httplib
     import urlparse
 


### PR DESCRIPTION
In some domains, there are unreachable domain controllers.  Since kdcproxy has to talk to a DC and may try to talk to an unreachable DC, this slows forwarding of requests, since kdcproxy will retry those DCs.

Windows makes use of an algorithm where, after joining a domain, a machine asks and persistently-remembers a close and functioning DC; this avoids the issue for Windows machines.

http://social.technet.microsoft.com/wiki/contents/articles/24457.how-domain-controllers-are-located-in-windows.aspx

This patch is less-elaborate -- it simply continues using a DC once it has stumbled across a working one -- but it avoids lengthy delays when crashing into blackholed DCs.
