### PR TITLE
Use dnspython package on Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,33 +20,18 @@
 # THE SOFTWARE.
 
 import os
-import sys
 
-import setuptools
 from setuptools import setup
-
-
-SETUPTOOLS_VERSION = tuple(int(v) for v in setuptools.__version__.split("."))
 
 install_requires = [
     'asn1crypto>=0.23',
+    'dnspython'
 ]
 
 extras_require = {
     "tests": ["pytest", "coverage", "WebTest"],
     "test_pep8": ['flake8', 'flake8-import-order', 'pep8-naming']
 }
-
-if SETUPTOOLS_VERSION >= (18, 0):
-    extras_require.update({
-        ":python_version<'3'": ["dnspython"],
-        ":python_version>='3'": ["dnspython3"],
-    })
-else:
-    if sys.version_info.major == 2:
-        install_requires.append("dnspython")
-    else:
-        install_requires.append("dnspython3")
 
 
 def read(fname):


### PR DESCRIPTION
The dnspython3 package is obsolete and superseded by dnspython. The dnspython
package supports Python 2 and Python 3.

The change also fixes a problem with Fedora 30's new Python dependency
generator. The python3-dnspython package does not provide dnspython3
distribution:

nothing provides python3.7dist(dnspython3) needed by python3-kdcproxy-0.4-4.fc30.noarch

See: https://pypi.org/project/dnspython3/
Signed-off-by: Christian Heimes <cheimes@redhat.com>