### PR TITLE
Make Application.__call__ portable

### DIFF
--- a/kdcproxy/__init__.py
+++ b/kdcproxy/__init__.py
@@ -19,6 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import errno
 import io
 import logging
 import select
@@ -255,7 +256,7 @@ class Application:
                             # Python 3.x, it throws io.BlockingIOError().
                             sock.connect(addr[4])
                         except socket.error as e:
-                            if e.errno != 115:  # errno != EINPROGRESS
+                            if e.errno != errno.EINPROGRESS:
                                 sock.close()
                                 continue
                         except io.BlockingIOError:


### PR DESCRIPTION
If a `socket.connect()` fails check `e.errno` in a portable fashion with
`errno.EINPROGRESS` instead of a platform-specific value.

Comparsion:

```
$ python3
Python 3.7.6 (default, Jan  8 2020, 08:45:21)
[Clang 8.0.1 (tags/RELEASE_801/final 366581)] on freebsd12
Type "help", "copyright", "credits" or "license" for more information.
>>> import errno
>>> errno.EINPROGRESS
36
```

```
$ python
Python 2.6.6 (r266:84292, Jun 11 2019, 11:01:44)
[GCC 4.4.7 20120313 (Red Hat 4.4.7-23)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import errno
>>> errno.EINPROGRESS
115
```

```
$ python3
Python 3.8.0+ (default, Oct 25 2019, 13:35:22) [C] on hp-ux11
Type "help", "copyright", "credits" or "license" for more information.
>>> import errno
>>> errno.EINPROGRESS
245
```

This issue was observed on FreeBSD.