### PR TITLE
Read default config file from multiple locations

### DIFF
--- a/README
+++ b/README
@@ -53,10 +53,11 @@ Master Configuration File
 If you wish to have more detailed configuration, the first place you can
 configure kdcproxy is the master configuration file. This file exists at the
 location specified in the environment variable KDCPROXY_CONFIG. If this
-variable is unspecified, the default location is /etc/kdcproxy.conf. This
-configuration file takes precedence over all other configuration modules. This
-file is an ini-style configuration with a special section **[global]**. Two
-parameters are available in this section: **configs** and **use_dns**.
+variable is unspecified, the default locations are
+`/usr/local/etc/kdcproxy.conf` or `/etc/kdcproxy.conf`. This configuration
+file takes precedence over all other configuration modules. This file is an
+ini-style configuration with a special section **[global]**. Two parameters
+are available in this section: **configs** and **use_dns**.
 
 The **use_dns** allows you to enable or disable use of DNS SRV record lookups.
 

--- a/kdcproxy/config/__init__.py
+++ b/kdcproxy/config/__init__.py
@@ -49,18 +49,18 @@ class IConfig(IResolver):
 
 class KDCProxyConfig(IConfig):
     GLOBAL = "global"
-    default_filename = "/etc/kdcproxy.conf"
+    default_filenames = ["/usr/local/etc/kdcproxy.conf", "/etc/kdcproxy.conf"]
 
-    def __init__(self, filename=None):
+    def __init__(self, filenames=None):
         self.__cp = configparser.ConfigParser()
-        if filename is None:
-            filename = os.environ.get("KDCPROXY_CONFIG", None)
-        if filename is None:
-            filename = self.default_filename
+        if filenames is None:
+            filenames = os.environ.get("KDCPROXY_CONFIG", None)
+        if filenames is None:
+            filenames = self.default_filenames
         try:
-            self.__cp.read(filename)
+            self.__cp.read(filenames)
         except configparser.Error:
-            logging.error("Unable to read config file: %s", filename)
+            logging.error("Unable to read config file(s): %s", filenames)
 
         try:
             mod = self.__cp.get(self.GLOBAL, "configs")


### PR DESCRIPTION
Additionally to /etc/kdcproxy.conf, load from /usr/local/etc/kdcproxy.conf
when Python has been installed manually or from a BSD pkg system.