### PR TITLE
Fix typo ; Prefix all logging messages with "kdcproxy:"

### DIFF
--- a/kdcproxy/__init__.py
+++ b/kdcproxy/__init__.py
@@ -101,7 +101,7 @@ class Application:
                         sock.sendall(pr.request)
                         extra = 10  # New connections get 10 extra seconds
                 except Exception as e:
-                    logging.warning("Conection broken while writing (%s)", e)
+                    logging.warning("Connection broken while writing (%s)", e)
                     continue
                 rsocks.append(sock)
                 wsocks.remove(sock)

--- a/kdcproxy/__init__.py
+++ b/kdcproxy/__init__.py
@@ -101,7 +101,8 @@ class Application:
                         sock.sendall(pr.request)
                         extra = 10  # New connections get 10 extra seconds
                 except Exception as e:
-                    logging.warning("Connection broken while writing (%s)", e)
+                    logging.warning(
+                        "kdcproxy: Connection broken while writing (%s)", e)
                     continue
                 rsocks.append(sock)
                 wsocks.remove(sock)
@@ -110,7 +111,8 @@ class Application:
                 try:
                     reply = self.__handle_recv(sock, read_buffers)
                 except Exception as e:
-                    logging.warning("Connection broken while reading (%s)", e)
+                    logging.warning(
+                        "kdcproxy: Connection broken while reading (%s)", e)
                     if self.sock_type(sock) == socket.SOCK_STREAM:
                         # Remove broken TCP socket from readers
                         rsocks.remove(sock)

--- a/kdcproxy/config/__init__.py
+++ b/kdcproxy/config/__init__.py
@@ -60,14 +60,16 @@ class KDCProxyConfig(IConfig):
         try:
             self.__cp.read(filenames)
         except configparser.Error:
-            logging.error("Unable to read config file(s): %s", filenames)
+            logging.error("kdcproxy: Unable to read config file(s): %s",
+                          filenames)
 
         try:
             mod = self.__cp.get(self.GLOBAL, "configs")
             try:
                 importlib.import_module("kdcproxy.config." + mod)
             except ImportError as e:
-                logging.log(logging.ERROR, "Error reading config: %s" % e)
+                logging.log(logging.ERROR,
+                            "kdcproxy: Error reading config: %s" % e)
         except configparser.Error:
             pass
 
@@ -134,7 +136,7 @@ class MetaResolver(IResolver):
             except Exception as e:
                 fmt = (allsub[i], repr(e))
                 logging.log(logging.WARNING,
-                            "Error instantiating %s due to %s" % fmt)
+                            "kdcproxy: Error instantiating %s due to %s" % fmt)
         assert self.__resolvers
 
         # See if we should use DNS


### PR DESCRIPTION
- Fix typo (Conection)

- Prefix all logging messages with "kdcproxy:"

    When running kdcproxy in mod_wsgi, it is unclear from which
    component error messages come from. For example:
    
    mod_wsgi.c(): [client WARNING:root:Connection broken while writing (...)
