### PR TITLE
Use exponential backoff for connection retries

### DIFF
--- a/kdcproxy/__init__.py
+++ b/kdcproxy/__init__.py
@@ -38,6 +38,9 @@ else:
     import httplib
     import urlparse
 
+logging.basicConfig()
+logger = logging.getLogger('kdcproxy')
+
 
 class HTTPException(Exception):
 
@@ -327,8 +330,8 @@ class Application:
                         fail_socktype = self.addr2socktypename(fail_addr)
                         fail_ip = fail_addr[4][0]
                         fail_port = fail_addr[4][1]
-                        logging.warning("Exchange with %s:[%s]:%d failed: %s",
-                                        fail_socktype, fail_ip, fail_port, e)
+                        logger.warning("Exchange with %s:[%s]:%d failed: %s",
+                                       fail_socktype, fail_ip, fail_port, e)
                     if reply is not None:
                         break
 

--- a/kdcproxy/config/__init__.py
+++ b/kdcproxy/config/__init__.py
@@ -32,6 +32,9 @@ except ImportError:  # Python 2.x
 import dns.rdatatype
 import dns.resolver
 
+logging.basicConfig()
+logger = logging.getLogger('kdcproxy')
+
 
 class IResolver(object):
 
@@ -60,14 +63,14 @@ class KDCProxyConfig(IConfig):
         try:
             self.__cp.read(filenames)
         except configparser.Error:
-            logging.error("Unable to read config file(s): %s", filenames)
+            logger.error("Unable to read config file(s): %s", filenames)
 
         try:
             mod = self.__cp.get(self.GLOBAL, "configs")
             try:
                 importlib.import_module("kdcproxy.config." + mod)
             except ImportError as e:
-                logging.log(logging.ERROR, "Error reading config: %s" % e)
+                logger.log(logging.ERROR, "Error reading config: %s" % e)
         except configparser.Error:
             pass
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,11 +28,12 @@ deps =
     doc8
     docutils
     markdown
+    rst2html
 basepython = python3
 commands =
     doc8 --allow-long-titles README
     python setup.py check --restructuredtext --metadata --strict
-    rst2html.py README {toxworkdir}/README.html
+    rst2html README {toxworkdir}/README.html
     markdown_py README.md -f {toxworkdir}/README.md.html
 
 [pytest]


### PR DESCRIPTION
Calls to `socket.connect()` are non-blocking, hence all subsequent calls to `socket.sendall()` will fail if the target KDC service is temporarily or indefinitely unreachable. Since the kdcproxy task uses busy-looping, it results in the journal to be flooded with warning logs.

This pull request introduces a per-socket reactivation delay which increases exponentially as the number of reties is incremented, until timeout is reached (i.e. 100ms, 200ms, 400ms, 800ms, 1.6s, 3.2s, ...).

(Also replaces the default `root` logger with a dedicated `kdcproxy` one)